### PR TITLE
Websocket direct connection for video preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+capture-node/thirdparty

--- a/capture-node/CMakeLists.txt
+++ b/capture-node/CMakeLists.txt
@@ -7,6 +7,8 @@ project("avaCapture")
 include(GitUtils.cmake)
 Git_GetCommitVersion()
 
+include(ExternalProject)
+
 #add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
 #add_definitions(-DRAPIDJSON_HAS_STDSTRING -DRAPIDJSON_HAS_CXX11_RVALUE_REFS)
 
@@ -38,9 +40,23 @@ else (PORTAUDIO_FOUND)
     set(PORTAUDIO_LIBRARIES "")
 endif (PORTAUDIO_FOUND)
 
+# websocketpp
+set(WEBSOCKETPP_ROOT ${CMAKE_BINARY_DIR}/thirdparty/websocketpp)
+set(WEBSOCKETPP_INCLUDE_DIR ${WEBSOCKETPP_ROOT}/src/websocketpp_external)
+ExternalProject_Add(websocketpp_external
+    PREFIX ${WEBSOCKETPP_ROOT}
+    GIT_REPOSITORY "https://github.com/zaphoyd/websocketpp.git"
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    CONFIGURE_COMMAND ""
+)
+include_directories(${WEBSOCKETPP_INCLUDE_DIR})
+message(${WEBSOCKETPP_INCLUDE_DIR})
+
 # set(CMAKE_BUILD_TYPE Debug)
 
 add_executable(avaCapture ${SOURCES})
+add_dependencies(avaCapture websocketpp_external)
 
 target_link_libraries(avaCapture ${PYTHON_LIBRARY} ${OpenCV_LIBS} ${Boost_LIBRARIES} ${PORTAUDIO_LIBRARIES} avcodec avformat avutil tbb m3api ${OPENSSL_LIBRARIES})
 

--- a/capture-node/CMakeLists.txt
+++ b/capture-node/CMakeLists.txt
@@ -9,6 +9,8 @@ Git_GetCommitVersion()
 
 include(ExternalProject)
 
+#add_definitions(-DUSE_TLS_WEBSOCKET)
+
 #add_definitions(-D_GLIBCXX_USE_CXX11_ABI=1)
 #add_definitions(-DRAPIDJSON_HAS_STDSTRING -DRAPIDJSON_HAS_CXX11_RVALUE_REFS)
 

--- a/capture-node/source/cameras.hpp
+++ b/capture-node/source/cameras.hpp
@@ -258,6 +258,23 @@ private:
 	boost::thread capture_thread;
 };
 
+class DummyCamera : public Camera
+{
+public:
+	DummyCamera(int id);
+
+	static std::vector<std::shared_ptr<Camera> > get_dummy_cameras(int count);
+
+protected:
+	void captureThread();
+	void start_capture() override;
+	void stop_capture() override;
+
+private:
+	int m_id;
+	boost::thread capture_thread;
+};
+
 #ifdef WITH_PORTAUDIO
 
 class AudioCamera : public Camera

--- a/capture-node/source/capturenode.cpp
+++ b/capture-node/source/capturenode.cpp
@@ -94,6 +94,14 @@ CaptureNode::CaptureNode(bool initializeWebcams, bool initializeAudio, const std
 		std::copy(webcam_cameras.begin(), webcam_cameras.end(), std::back_inserter(m_cameras));
 	}
 
+	// Initialize a dummy camera for testing
+	if (0)
+	{ 
+		std::vector<std::shared_ptr<Camera> > dummy_cameras = DummyCamera::get_dummy_cameras(1);
+		std::copy(dummy_cameras.begin(), dummy_cameras.end(), std::back_inserter(m_cameras));
+	}
+
+
 #ifdef WITH_PORTAUDIO	
 	// Enable first audio device
 	if (initializeAudio)

--- a/capture-node/source/capturenode.cpp
+++ b/capture-node/source/capturenode.cpp
@@ -13,7 +13,7 @@
 #include <iostream>
 #include <iterator>
 
-CaptureNode::CaptureNode(bool initializeWebcams, bool initializeAudio, const std::string& recording_folder) 
+CaptureNode::CaptureNode(bool initializeWebcams, bool initializeAudio, bool initializeDummyCam, const std::string& recording_folder) 
 	: m_sync_active(false), m_shutdownrequested(false)
 {
 	m_external_sync_always = false;
@@ -95,7 +95,7 @@ CaptureNode::CaptureNode(bool initializeWebcams, bool initializeAudio, const std
 	}
 
 	// Initialize a dummy camera for testing
-	if (0)
+	if (initializeDummyCam)
 	{ 
 		std::vector<std::shared_ptr<Camera> > dummy_cameras = DummyCamera::get_dummy_cameras(1);
 		std::copy(dummy_cameras.begin(), dummy_cameras.end(), std::back_inserter(m_cameras));

--- a/capture-node/source/capturenode.hpp
+++ b/capture-node/source/capturenode.hpp
@@ -12,7 +12,7 @@
 class CaptureNode
 {
 public:
-	CaptureNode(bool initializeWebcams, bool initializeAudio, const std::string& recording_folder = std::string());
+	CaptureNode(bool initializeWebcams, bool initializeAudio, bool initializeDummyCam, const std::string& recording_folder = std::string());
 	~CaptureNode();
 
 	const std::vector<std::shared_ptr<Camera> > cameraList();

--- a/capture-node/source/main.cpp
+++ b/capture-node/source/main.cpp
@@ -142,7 +142,7 @@ int main(int argc, char** argv)
 
 	// Websocker Server
 	NodeWSServer wdd(node, 9002);
-	boost::thread wd_thread([&wdd]() {wdd.serve_forever(); });
+	wdd.serve_forever_in_thread();
 
 	// Up-link to server
 	ServerUplink uplink(node, vm["server"].as<std::string>().c_str(), vm["port"].as<int>(), USERNAME, PASSWORD, GIT_REVISION);
@@ -306,7 +306,6 @@ int main(int argc, char** argv)
 	httpd.close();
 	http_thread.join();	
 	wdd.close();
-	wd_thread.join();	
 
 	if (node->shutdown_requested())
 	{

--- a/capture-node/source/main.cpp
+++ b/capture-node/source/main.cpp
@@ -96,6 +96,7 @@ int main(int argc, char** argv)
 		("server", po::value<std::string>()->default_value(DEFAULT_SERVER), "Server address")
 		("port", po::value<int>()->default_value(DEFAULT_PORT), "Port of the server")
 		("webcams", po::bool_switch()->default_value(false), "Initialize all available Webcams")
+		("dummy", po::bool_switch()->default_value(false), "Add dummy test camera")
 		("service", po::bool_switch()->default_value(false), "Run without the interactive prompt")
 #ifdef WITH_PORTAUDIO		
 		("audio", po::bool_switch()->default_value(false), "Initialize default audio capture device")
@@ -132,9 +133,10 @@ int main(int argc, char** argv)
 #else
 	const bool use_audio = false;
 #endif
+	const bool use_dummycam = vm["dummy"].as<bool>();
 	std::string folder = vm["folder"].as<std::string>();
 
-	std::shared_ptr<CaptureNode> node(new CaptureNode(use_webcams, use_audio, folder));
+	std::shared_ptr<CaptureNode> node(new CaptureNode(use_webcams, use_audio, use_dummycam, folder));
 
 	// HTTP Server
 	NodeHttpServer httpd(node, 8080);

--- a/capture-node/source/node_ws_server.cpp
+++ b/capture-node/source/node_ws_server.cpp
@@ -1,0 +1,92 @@
+// Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+#include <functional>
+
+#include "node_ws_server.hpp"
+#include "capturenode.hpp"
+#include "base64.hpp"
+
+#include <boost/algorithm/string.hpp>
+
+WSServer::WSServer(int port)
+{
+    server.init_asio();
+    server.set_message_handler(std::bind(&WSServer::on_message, this, std::placeholders::_1, std::placeholders::_2));
+    server.listen(port);
+    server.start_accept();   
+}
+
+WSServer::~WSServer()
+{
+}
+
+void WSServer::serve_forever()
+{
+    server.run();
+}
+	
+void WSServer::close()
+{
+    //std::cout << "WEBSOCKET> Shutting down" << std::endl;
+
+    server.stop_listening();
+    server.stop();
+}
+
+void WSServer::on_message(websocketpp::connection_hdl hdl, ws_server::message_ptr msg)
+{
+    //std::cout << "WEBSOCKET> message:" << msg->get_payload() << std::endl;
+}
+
+void WSServer::send(websocketpp::connection_hdl hdl, const std::string& s)
+{
+    server.send(hdl, s, websocketpp::frame::opcode::text);
+}
+
+NodeWSServer::NodeWSServer(std::shared_ptr<CaptureNode> pNode, int port)
+  : WSServer(port), m_node(pNode)
+{
+}
+
+NodeWSServer::~NodeWSServer()
+{
+}
+
+void NodeWSServer::on_message(websocketpp::connection_hdl hdl, ws_server::message_ptr msg)
+{
+    //std::cout << "WEBSOCKET> message:" << msg->get_payload() << std::endl;
+
+	std::vector<std::string> paths;
+	boost::split(paths, msg->get_payload(), boost::is_any_of("/"), boost::token_compress_on);
+
+    if (paths.size()<3 || msg->get_opcode()!=websocketpp::frame::opcode::text)
+        return;
+
+    if (paths[0]=="capture")
+    {
+        std::string camUniqueId = paths[1];
+        std::string action = paths[2];
+
+        auto cam = m_node->cameraById(camUniqueId.c_str());
+        if (!cam.get())
+            return;
+
+        if (action=="large_preview")
+        {
+            std::vector<unsigned char> buf;
+            if (cam->get_large_preview_image(buf))
+            {
+        	    send(hdl, base64encode(buf));
+            }
+        }
+        else if (action=="preview")
+        {
+            std::vector<unsigned char> buf;
+            bool is_histogram = false;
+            if (cam->get_preview_image(buf), &is_histogram)
+            {
+        	    send(hdl, camUniqueId + ";" + base64encode(buf));
+            }
+        }
+    }
+}

--- a/capture-node/source/node_ws_server.cpp
+++ b/capture-node/source/node_ws_server.cpp
@@ -42,6 +42,7 @@ context_ptr on_tls_init(websocketpp::connection_hdl)
 WSServer::WSServer(int port)
 {
     server.init_asio();
+	server.set_reuse_addr(true);
 #ifdef USE_TLS_WEBSOCKET
     server.set_tls_init_handler(&on_tls_init);
 #endif

--- a/capture-node/source/node_ws_server.cpp
+++ b/capture-node/source/node_ws_server.cpp
@@ -45,6 +45,7 @@ WSServer::WSServer(int port)
 #ifdef USE_TLS_WEBSOCKET
     server.set_tls_init_handler(&on_tls_init);
 #endif
+    server.clear_access_channels(websocketpp::log::alevel::frame_header | websocketpp::log::alevel::frame_payload); 
     server.set_message_handler(std::bind(&WSServer::on_message, this, std::placeholders::_1, std::placeholders::_2));
     server.listen(port);
     server.start_accept();   

--- a/capture-node/source/node_ws_server.hpp
+++ b/capture-node/source/node_ws_server.hpp
@@ -1,0 +1,41 @@
+// Copyright (C) 2017 Electronic Arts Inc.  All rights reserved.
+
+#pragma once
+
+#include <memory>
+
+#include <websocketpp/config/asio_no_tls.hpp>
+#include <websocketpp/server.hpp>
+typedef websocketpp::server<websocketpp::config::asio> ws_server;
+
+class CaptureNode;
+struct WSServerPrivate;
+
+class WSServer
+{
+public:
+	WSServer(int port);
+	virtual ~WSServer();
+	void serve_forever();
+	void close();
+
+protected:
+	void send(websocketpp::connection_hdl hdl, const std::string& s);
+	virtual void on_message(websocketpp::connection_hdl hdl, ws_server::message_ptr msg);
+
+private:
+	ws_server server;
+};
+
+class NodeWSServer : public WSServer
+{
+public:
+	NodeWSServer(std::shared_ptr<CaptureNode> pNode, int port);
+	virtual ~NodeWSServer();
+
+protected:
+	void on_message(websocketpp::connection_hdl hdl, ws_server::message_ptr msg) override;
+
+private:
+	std::shared_ptr<CaptureNode> m_node;
+};

--- a/website-frontend/package.json
+++ b/website-frontend/package.json
@@ -86,7 +86,9 @@
 
     "webpack": "2.4.1",
     "webpack-dev-server": "2.4.2",
-    "webpack-merge": "^4.1.0"
+    "webpack-merge": "^4.1.0",
+
+    "angular2-websocket": "0.9.6"
 
   },
   "repository": {}

--- a/website-frontend/src/app/capture/live.html
+++ b/website-frontend/src/app/capture/live.html
@@ -96,12 +96,6 @@
     </div>
     <div class="split-columns">
       <small>
-        <select class="form-control form-control-dark" [(ngModel)]="thumbnail_preview_fps">
-          <option [value]="0.5">Preview @ 0.5 fps</option>
-          <option [value]="1">Preview @ 1 fps</option>
-          <option [value]="5">Preview @ 5 fps</option>
-          <option [value]="15">Preview @ 15 fps</option>
-        </select>
         <div>AVI:
         <select class="form-control form-control-dark" [(ngModel)]="bitdepth_avi" (ngModelChange)="onChangeLocationOption($event)">
           <option [value]="8">8</option>

--- a/website-frontend/src/app/capture/live.ts
+++ b/website-frontend/src/app/capture/live.ts
@@ -14,6 +14,7 @@ import { SessionNameComponent } from './sessionname.component';
 import { ZoomViewComponent } from './zoomview.component';
 
 import { LoadDataEveryMs } from '../../utils/reloader';
+import { LiveNodeLink } from './live_link';
 
 var $ = require("jquery");
 
@@ -61,6 +62,7 @@ export class LiveCapturePage {
   bitdepth_single = 8;
 
   loader = new LoadDataEveryMs();
+  livelink = new LiveNodeLink();
 
   project_id = 0;
   project_name = '';
@@ -84,7 +86,7 @@ export class LiveCapturePage {
 
   available_freqs = [10, 20, 24, 30, 40, 50, 60, 70, 72, 80, 90, 100, 120];
 
-  thumbnail_preview_fps = 5;
+  thumbnail_preview_fps = 5; // Update camera details at 5 fps
 
   camera_view_mode = 0;
 
@@ -402,6 +404,8 @@ export class LiveCapturePage {
         this.capturenodes = data.nodes;
         this.capturenodes['counter'] = this.counter++;
 
+        this.livelink.update_from_nodes(data.nodes);
+
         // Update list of unique camera models
         var updated_camera_count = 0;
         var updated_syncs_found = 0;
@@ -453,6 +457,8 @@ export class LiveCapturePage {
 
       this.location_id = +params['id']; // (+) converts string 'id' to a number
 
+      this.livelink.set_location(this.location_id);
+
       this.captureService.getLocationName(this.location_id).subscribe(
           data => {
             this.location_name = data;
@@ -483,6 +489,9 @@ export class LiveCapturePage {
 
   ngOnDestroy(): void {
     this.cancelSubscriptions();
+
+    this.livelink.release();
+    this.livelink = null;
   }
 
 }

--- a/website-frontend/src/app/capture/live.ts
+++ b/website-frontend/src/app/capture/live.ts
@@ -401,10 +401,10 @@ export class LiveCapturePage {
         this.pulse_duration = data.location.pulse_duration;
         this.external_sync = data.location.external_sync?1:0;
 
+        this.livelink.update_from_nodes(data.nodes);
+
         this.capturenodes = data.nodes;
         this.capturenodes['counter'] = this.counter++;
-
-        this.livelink.update_from_nodes(data.nodes);
 
         // Update list of unique camera models
         var updated_camera_count = 0;

--- a/website-frontend/src/app/capture/live_link.ts
+++ b/website-frontend/src/app/capture/live_link.ts
@@ -10,6 +10,7 @@ export class NodeLink
     node_ptr : any = null;
     ws : any = null;
     camera_list = Array();
+    cache = {};
 
     constructor(node : any) {
         // Initialize and create one websocket
@@ -49,11 +50,14 @@ export class NodeLink
 
         // Update node data with new image
         var framerate = 0;
-        this.node_ptr.camera_details.forEach(cam => {
+        this.node_ptr.camera_details.some(cam => {
             if (cam.unique_id == unique_id) {
                 cam.jpeg_thumbnail = image_b64;
                 framerate = cam.effective_fps;
+                this.cache[cam.unique_id] = image_b64;
+                return true; // stops iterating
             }
+            return false; // continue iteration
         });
 
         // after a delay, request next image
@@ -67,6 +71,11 @@ export class NodeLink
 
     set_camera_list(node, camera_list) {
         this.node_ptr = node;
+        this.node_ptr.camera_details.forEach(cam => {
+            if (cam.unique_id in this.cache) {
+                cam.jpeg_thumbnail = cache[cam.unique_id];
+            }
+        });        
         this.camera_list = camera_list;
     }
 

--- a/website-frontend/src/app/capture/live_link.ts
+++ b/website-frontend/src/app/capture/live_link.ts
@@ -76,11 +76,13 @@ export class NodeLink
 
     set_camera_list(node, camera_list) {
         this.node_ptr = node;
-        this.node_ptr.camera_details.forEach(cam => {
-            if (cam.unique_id in this.cache) {
-                cam.jpeg_thumbnail = this.cache[cam.unique_id];
-            }
-        });        
+        if (this.node_ptr.camera_details) {
+            this.node_ptr.camera_details.forEach(cam => {
+                if (cam.unique_id in this.cache) {
+                    cam.jpeg_thumbnail = this.cache[cam.unique_id];
+                }
+            });            
+        }
         this.camera_list = camera_list;
     }
 

--- a/website-frontend/src/app/capture/live_link.ts
+++ b/website-frontend/src/app/capture/live_link.ts
@@ -1,0 +1,130 @@
+//
+// Copyright (c) 2017 Electronic Arts Inc. All Rights Reserved 
+//
+
+import {$WebSocket, WebSocketSendMode, WebSocketConfig} from 'angular2-websocket/angular2-websocket';
+
+export class NodeLink
+{
+    node_id : number = -1;
+    node_ptr : any = null;
+    ws : any = null;
+    camera_list = Array();
+
+    constructor(node : any) {
+        // Initialize and create one websocket
+        this.node_id = node.id;
+        this.node_ptr = node;
+        const webSocketConfig = {reconnectIfNotNormalClose: true} as WebSocketConfig;
+        var websocket_protocol = location.protocol=="https:" ? "wss:" : "ws:";
+        this.ws = new $WebSocket(websocket_protocol + "//"+node.ip_address+":9002", null, webSocketConfig);
+        this.ws.onMessage(
+            (msg: MessageEvent)=> {
+                var res = msg.data.split(";", 2);
+                if (res.length==2) {
+                    this.got_preview_image(res[0], res[1]);
+                }
+            },
+            {autoApply: false}
+          ); 
+          this.ws.onOpen(
+            (msg: Event)=> {
+                console.log("Websocket Connected!");
+                // Communication channel open, start requesting thumbnails
+                this.camera_list.forEach(cam => {
+                    this.ws.send("capture/"+cam+"/preview").subscribe();
+                });
+            },
+            {autoApply: false}
+          ); 
+          this.ws.onClose(
+            (msg: CloseEvent)=> {
+                console.log("Websocket closed");
+            },
+            {autoApply: false}
+          ); 
+    }
+
+    private got_preview_image(unique_id, image_b64) {
+
+        // Update node data with new image
+        var framerate = 0;
+        this.node_ptr.camera_details.forEach(cam => {
+            if (cam.unique_id == unique_id) {
+                cam.jpeg_thumbnail = image_b64;
+                framerate = cam.effective_fps;
+            }
+        });
+
+        // after a delay, request next image
+        var delay_ms = Math.max(Math.min(1000.0 / framerate, 1000), 10);
+        setTimeout(() => {
+            if (this.camera_list.indexOf(unique_id)>=0) {
+                this.ws.send("capture/"+unique_id+"/preview").subscribe();
+            }
+        }, delay_ms);
+    }
+
+    set_camera_list(node, camera_list) {
+        this.node_ptr = node;
+        this.camera_list = camera_list;
+    }
+
+    release() {
+        this.camera_list = Array();
+        if (this.ws) {
+            this.ws.close(false);
+        }
+    }
+}
+
+export class LiveNodeLink
+{
+    location_id : number = -1;
+    node_map = new Map();
+
+    constructor() {
+    }
+
+    set_location(loc_id) {
+        if (loc_id != this.location_id) {
+            this.release(); 
+            this.location_id = loc_id;
+        }
+    }
+
+    release() {
+        this.node_map.forEach(element => {
+            element.release();
+        });
+        this.node_map.clear();
+    }
+
+    update_from_nodes(nodes : any) {
+        if (nodes) {
+            var node_id_list = Array();
+            nodes.forEach(node => {
+                node_id_list.push(node.id);
+                if (!this.node_map.has(node.id)) {
+                    this.node_map.set(node.id, new NodeLink(node));
+                }
+                var cams = Array();
+                node.cameras.forEach(cam => {
+                    cams.push(cam.unique_id);
+                });
+                this.node_map.get(node.id).set_camera_list(node, cams);
+            });
+            var to_delete = Array();
+            this.node_map.forEach(element => {
+                if (node_id_list.indexOf(element.node_id)<0) {
+                    to_delete.push(element.node_id);
+                }
+            });
+            to_delete.forEach(id => {
+                this.node_map.get(id).release();
+                this.node_map.delete(id);
+            });
+        }
+    }
+}
+

--- a/website-frontend/src/app/capture/live_link.ts
+++ b/website-frontend/src/app/capture/live_link.ts
@@ -73,7 +73,7 @@ export class NodeLink
         this.node_ptr = node;
         this.node_ptr.camera_details.forEach(cam => {
             if (cam.unique_id in this.cache) {
-                cam.jpeg_thumbnail = cache[cam.unique_id];
+                cam.jpeg_thumbnail = this.cache[cam.unique_id];
             }
         });        
         this.camera_list = camera_list;

--- a/website-frontend/src/app/capture/live_link.ts
+++ b/website-frontend/src/app/capture/live_link.ts
@@ -16,9 +16,14 @@ export class NodeLink
         // Initialize and create one websocket
         this.node_id = node.id;
         this.node_ptr = node;
+
         const webSocketConfig = {reconnectIfNotNormalClose: true} as WebSocketConfig;
-        var websocket_protocol = location.protocol=="https:" ? "wss:" : "ws:";
-        this.ws = new $WebSocket(websocket_protocol + "//"+node.ip_address+":9002", null, webSocketConfig);
+        if (location.protocol=="https:") {
+            this.ws = new $WebSocket("wss://"+node.machine_name+":9003", null, webSocketConfig);
+        } else {
+            this.ws = new $WebSocket("ws://"+node.ip_address+":9002", null, webSocketConfig);
+        }      
+
         this.ws.onMessage(
             (msg: MessageEvent)=> {
                 var res = msg.data.split(";", 2);


### PR DESCRIPTION
Instead of getting preview images for each camera thru the server requests, the frontend can now directly connect to the capture nodes via websocket. The resulting preview strem is much more responsive if the frontend client, and the capture nodes are on the same network.  The preview will fall back to the slower method if the capture nodes cannot be reached directly.
If the frontend is served as HTTPS, the websocket connection to the capture node will need to be secure (browser limitation). The SSL certificate and private key need to be placed in the same folder as the avaCapture executable, and called server_cert.pem and server_key.pem